### PR TITLE
MAS-311 handle an empty registrations request

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/client/CommunityApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/client/CommunityApiClient.kt
@@ -156,5 +156,5 @@ data class Registration @JsonCreator constructor(
 
 private data class CommunityApiRegistrationsDto @JsonCreator constructor(
   @JsonProperty("registrations")
-  val registrations: List<Registration>
+  val registrations: List<Registration>?
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/ApiResponses.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/ApiResponses.kt
@@ -9,6 +9,7 @@ object ApiResponses {
     Files.readString(Paths.get("src/test/resources/fixtures/community-api/assessments.json"))
   fun registrationsResponse(): String =
     Files.readString(Paths.get("src/test/resources/fixtures/community-api/registrations.json"))
+  fun emptyRegistrationsResponse(): String = "{}"
   fun custodialSCConvictionResponse(): String =
     Files.readString(Paths.get("src/test/resources/fixtures/community-api/convictions-custodial-sc.json"))
   fun custodialNCConvictionResponse(): String =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/MissingRegistrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/MissingRegistrationTest.kt
@@ -1,53 +1,70 @@
 package uk.gov.justice.digital.hmpps.hmppstier.integration
 
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.mockserver.integration.ClientAndServer
+import org.mockserver.matchers.Times
+import org.mockserver.model.HttpRequest
+import org.mockserver.model.HttpResponse
+import org.mockserver.model.MediaType
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ChangeLevel
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ProtectLevel
-import uk.gov.justice.digital.hmpps.hmppstier.service.TierCalculationService
+import uk.gov.justice.digital.hmpps.hmppstier.integration.ApiResponses.emptyRegistrationsResponse
+import uk.gov.justice.digital.hmpps.hmppstier.jpa.repository.TierCalculationRepository
+import uk.gov.justice.digital.hmpps.hmppstier.service.TierCalculationRequiredEventListener
+import java.nio.file.Files
+import java.nio.file.Paths
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class MissingRegistrationTest : IntegrationTestBase() {
+class MissingRegistrationTest : MockedEndpointsTestBase() {
 
   @Autowired
-  lateinit var service: TierCalculationService
+  lateinit var listener: TierCalculationRequiredEventListener
 
-  // TODO move into a base class
-  lateinit var mockCommunityApiServer: ClientAndServer
-  lateinit var mockAssessmentApiServer: ClientAndServer
-
-  @BeforeAll
-  fun setupMockServer() {
-    mockCommunityApiServer = ClientAndServer.startClientAndServer(8081)
-    mockAssessmentApiServer = ClientAndServer.startClientAndServer(8082)
-  }
-
-  @AfterEach
-  fun reset() {
-    mockCommunityApiServer.reset()
-    mockAssessmentApiServer.reset()
-  }
-
-  @AfterAll
-  fun tearDownServer() {
-    mockCommunityApiServer.stop()
-    mockAssessmentApiServer.stop()
-  }
+  @Autowired
+  lateinit var repo: TierCalculationRepository
 
   @Test
   fun `calculate change and protect when no registrations are found`() {
-//    setupSCCustodialSentence()
-//    restOfSetup()
+    val crn = "X373878"
+    setupNCCustodialSentence(crn)
+    setupRegistrations(emptyRegistrationsResponse(), crn)
+    restOfSetup(crn)
+    val validMessage: String =
+      Files.readString(Paths.get("src/test/resources/fixtures/sqs/tier-calculation-event.json"))
+    listener.listen(validMessage)
+    val tier = repo.findFirstByCrnOrderByCreatedDesc(crn)
 
-    val tier = service.calculateTierForCrn("123")
-    Assertions.assertThat(tier.data.change.tier).isEqualTo(ChangeLevel.ONE)
-    Assertions.assertThat(tier.data.protect.tier).isEqualTo(ProtectLevel.A)
+    Assertions.assertThat(tier?.data?.change?.tier).isEqualTo(ChangeLevel.ONE)
+    Assertions.assertThat(tier?.data?.protect?.tier).isEqualTo(ProtectLevel.B)
   }
 
+  private fun restOfSetup(crn: String) {
+    mockCommunityApiServer.`when`(HttpRequest.request().withPath("/offenders/crn/$crn/assessments")).respond(
+      HttpResponse.response().withContentType(
+        MediaType.APPLICATION_JSON
+      ).withBody(ApiResponses.communityApiAssessmentsResponse())
+    )
+
+    mockCommunityApiServer.`when`(HttpRequest.request().withPath("/offenders/crn/$crn")).respond(
+      HttpResponse.response().withContentType(
+        MediaType.APPLICATION_JSON
+      ).withBody(ApiResponses.offenderResponse())
+    )
+    mockAssessmentApiServer.`when`(
+      HttpRequest.request().withPath("/offenders/crn/$crn/assessments/latest"),
+      Times.exactly(2)
+    )
+      .respond(
+        HttpResponse.response().withContentType(
+          MediaType.APPLICATION_JSON
+        ).withBody(ApiResponses.assessmentsApiAssessmentsResponse())
+      )
+    mockAssessmentApiServer.`when`(HttpRequest.request().withPath("/assessments/oasysSetId/1234/needs")).respond(
+      HttpResponse.response().withContentType(
+        MediaType.APPLICATION_JSON
+      ).withBody(ApiResponses.assessmentsApiNeedsResponse())
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/MissingRegistrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/MissingRegistrationTest.kt
@@ -1,22 +1,19 @@
 package uk.gov.justice.digital.hmpps.hmppstier.integration
 
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.mockserver.matchers.Times
-import org.mockserver.model.HttpRequest
-import org.mockserver.model.HttpResponse
-import org.mockserver.model.MediaType
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ChangeLevel
-import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ProtectLevel
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ChangeLevel.ONE
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ProtectLevel.B
 import uk.gov.justice.digital.hmpps.hmppstier.integration.ApiResponses.emptyRegistrationsResponse
 import uk.gov.justice.digital.hmpps.hmppstier.jpa.repository.TierCalculationRepository
 import uk.gov.justice.digital.hmpps.hmppstier.service.TierCalculationRequiredEventListener
 import java.nio.file.Files
 import java.nio.file.Paths
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(PER_CLASS)
 class MissingRegistrationTest : MockedEndpointsTestBase() {
 
   @Autowired
@@ -36,35 +33,7 @@ class MissingRegistrationTest : MockedEndpointsTestBase() {
     listener.listen(validMessage)
     val tier = repo.findFirstByCrnOrderByCreatedDesc(crn)
 
-    Assertions.assertThat(tier?.data?.change?.tier).isEqualTo(ChangeLevel.ONE)
-    Assertions.assertThat(tier?.data?.protect?.tier).isEqualTo(ProtectLevel.B)
-  }
-
-  private fun restOfSetup(crn: String) {
-    mockCommunityApiServer.`when`(HttpRequest.request().withPath("/offenders/crn/$crn/assessments")).respond(
-      HttpResponse.response().withContentType(
-        MediaType.APPLICATION_JSON
-      ).withBody(ApiResponses.communityApiAssessmentsResponse())
-    )
-
-    mockCommunityApiServer.`when`(HttpRequest.request().withPath("/offenders/crn/$crn")).respond(
-      HttpResponse.response().withContentType(
-        MediaType.APPLICATION_JSON
-      ).withBody(ApiResponses.offenderResponse())
-    )
-    mockAssessmentApiServer.`when`(
-      HttpRequest.request().withPath("/offenders/crn/$crn/assessments/latest"),
-      Times.exactly(2)
-    )
-      .respond(
-        HttpResponse.response().withContentType(
-          MediaType.APPLICATION_JSON
-        ).withBody(ApiResponses.assessmentsApiAssessmentsResponse())
-      )
-    mockAssessmentApiServer.`when`(HttpRequest.request().withPath("/assessments/oasysSetId/1234/needs")).respond(
-      HttpResponse.response().withContentType(
-        MediaType.APPLICATION_JSON
-      ).withBody(ApiResponses.assessmentsApiNeedsResponse())
-    )
+    assertThat(tier?.data?.change?.tier).isEqualTo(ONE)
+    assertThat(tier?.data?.protect?.tier).isEqualTo(B)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/MissingRegistrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/MissingRegistrationTest.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.hmppstier.integration
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockserver.integration.ClientAndServer
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ChangeLevel
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ProtectLevel
+import uk.gov.justice.digital.hmpps.hmppstier.service.TierCalculationService
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MissingRegistrationTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var service: TierCalculationService
+
+  // TODO move into a base class
+  lateinit var mockCommunityApiServer: ClientAndServer
+  lateinit var mockAssessmentApiServer: ClientAndServer
+
+  @BeforeAll
+  fun setupMockServer() {
+    mockCommunityApiServer = ClientAndServer.startClientAndServer(8081)
+    mockAssessmentApiServer = ClientAndServer.startClientAndServer(8082)
+  }
+
+  @AfterEach
+  fun reset() {
+    mockCommunityApiServer.reset()
+    mockAssessmentApiServer.reset()
+  }
+
+  @AfterAll
+  fun tearDownServer() {
+    mockCommunityApiServer.stop()
+    mockAssessmentApiServer.stop()
+  }
+
+  @Test
+  fun `calculate change and protect when no registrations are found`() {
+//    setupSCCustodialSentence()
+//    restOfSetup()
+
+    val tier = service.calculateTierForCrn("123")
+    Assertions.assertThat(tier.data.change.tier).isEqualTo(ChangeLevel.ONE)
+    Assertions.assertThat(tier.data.protect.tier).isEqualTo(ProtectLevel.A)
+  }
+
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/MockedEndpointsTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/MockedEndpointsTestBase.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.hmppstier.integration
+
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.mockserver.integration.ClientAndServer
+
+abstract class MockedEndpointsTestBase: IntegrationTestBase() {
+  lateinit var mockCommunityApiServer: ClientAndServer
+  lateinit var mockAssessmentApiServer: ClientAndServer
+
+  @BeforeAll
+  fun setupMockServer() {
+    mockCommunityApiServer = ClientAndServer.startClientAndServer(8081)
+    mockAssessmentApiServer = ClientAndServer.startClientAndServer(8082)
+  }
+
+  @AfterEach
+  fun reset() {
+    mockCommunityApiServer.reset()
+    mockAssessmentApiServer.reset()
+  }
+
+  @AfterAll
+  fun tearDownServer() {
+    mockCommunityApiServer.stop()
+    mockAssessmentApiServer.stop()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/MockedEndpointsTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/MockedEndpointsTestBase.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.mockserver.integration.ClientAndServer
+import org.mockserver.matchers.Times
 import org.mockserver.model.HttpRequest
 import org.mockserver.model.HttpResponse
 import org.mockserver.model.MediaType.APPLICATION_JSON
@@ -43,6 +44,34 @@ abstract class MockedEndpointsTestBase : IntegrationTestBase() {
       HttpResponse.response().withContentType(
         APPLICATION_JSON
       ).withBody(registrationsResponse)
+    )
+  }
+
+  fun restOfSetup(crn: String) {
+    mockCommunityApiServer.`when`(HttpRequest.request().withPath("/offenders/crn/$crn/assessments")).respond(
+      HttpResponse.response().withContentType(
+        APPLICATION_JSON
+      ).withBody(ApiResponses.communityApiAssessmentsResponse())
+    )
+
+    mockCommunityApiServer.`when`(HttpRequest.request().withPath("/offenders/crn/$crn")).respond(
+      HttpResponse.response().withContentType(
+        APPLICATION_JSON
+      ).withBody(ApiResponses.offenderResponse())
+    )
+    mockAssessmentApiServer.`when`(
+      HttpRequest.request().withPath("/offenders/crn/$crn/assessments/latest"),
+      Times.exactly(2)
+    )
+      .respond(
+        HttpResponse.response().withContentType(
+          APPLICATION_JSON
+        ).withBody(ApiResponses.assessmentsApiAssessmentsResponse())
+      )
+    mockAssessmentApiServer.`when`(HttpRequest.request().withPath("/assessments/oasysSetId/1234/needs")).respond(
+      HttpResponse.response().withContentType(
+        APPLICATION_JSON
+      ).withBody(ApiResponses.assessmentsApiNeedsResponse())
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/MockedEndpointsTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/MockedEndpointsTestBase.kt
@@ -4,8 +4,11 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.mockserver.integration.ClientAndServer
+import org.mockserver.model.HttpRequest
+import org.mockserver.model.HttpResponse
+import org.mockserver.model.MediaType.APPLICATION_JSON
 
-abstract class MockedEndpointsTestBase: IntegrationTestBase() {
+abstract class MockedEndpointsTestBase : IntegrationTestBase() {
   lateinit var mockCommunityApiServer: ClientAndServer
   lateinit var mockAssessmentApiServer: ClientAndServer
 
@@ -25,5 +28,21 @@ abstract class MockedEndpointsTestBase: IntegrationTestBase() {
   fun tearDownServer() {
     mockCommunityApiServer.stop()
     mockAssessmentApiServer.stop()
+  }
+
+  fun setupNCCustodialSentence(crn: String) {
+    mockCommunityApiServer.`when`(HttpRequest.request().withPath("/offenders/crn/$crn/convictions")).respond(
+      HttpResponse.response().withContentType(
+        APPLICATION_JSON
+      ).withBody(ApiResponses.custodialNCConvictionResponse())
+    )
+  }
+
+  fun setupRegistrations(registrationsResponse: String, crn: String) {
+    mockCommunityApiServer.`when`(HttpRequest.request().withPath("/offenders/crn/$crn/registrations")).respond(
+      HttpResponse.response().withContentType(
+        APPLICATION_JSON
+      ).withBody(registrationsResponse)
+    )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/TierCalculationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/TierCalculationTest.kt
@@ -16,31 +16,10 @@ import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ChangeLevel
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ProtectLevel
 import uk.gov.justice.digital.hmpps.hmppstier.service.TierCalculationService
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class TierCalculationTest : IntegrationTestBase() {
+class TierCalculationTest : MockedEndpointsTestBase() {
 
   @Autowired
   lateinit var service: TierCalculationService
-
-  lateinit var mockCommunityApiServer: ClientAndServer
-  lateinit var mockAssessmentApiServer: ClientAndServer
-
-  @BeforeAll
-  fun setupMockServer() {
-    mockCommunityApiServer = ClientAndServer.startClientAndServer(8081)
-    mockAssessmentApiServer = ClientAndServer.startClientAndServer(8082)
-  }
-
-  @AfterEach
-  fun reset() {
-    mockCommunityApiServer.reset()
-    mockAssessmentApiServer.reset()
-  }
-
-  @AfterAll
-  fun tearDownServer() {
-    mockCommunityApiServer.stop()
-    mockAssessmentApiServer.stop()
-  }
 
   @Test
   fun `calculate change and protect for SC custodial sentence`() {


### PR DESCRIPTION
I took the opportunity to write something pretty close to an end to end integration test - calling the listener and checking it writes the calculated tier to the repository