### PR TITLE
Reduce the message quantity to avoid the rate limits, and scale the a…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/config/AwsConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/config/AwsConfiguration.kt
@@ -39,7 +39,7 @@ class AwsConfiguration(
     SimpleMessageListenerContainerFactory {
       val factory = SimpleMessageListenerContainerFactory()
       factory.setAmazonSqs(amazonSQSAsync)
-      factory.setMaxNumberOfMessages(2)
+      factory.setMaxNumberOfMessages(1)
       factory.setWaitTimeOut(20)
       return factory
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/config/AwsLocalStackConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/config/AwsLocalStackConfiguration.kt
@@ -39,7 +39,7 @@ class AwsLocalStackConfiguration(
     SimpleMessageListenerContainerFactory {
       val factory = SimpleMessageListenerContainerFactory()
       factory.setAmazonSqs(amazonSQSAsync)
-      factory.setMaxNumberOfMessages(10)
+      factory.setMaxNumberOfMessages(1)
       factory.setWaitTimeOut(20)
       return factory
     }


### PR DESCRIPTION
…pplication to 2 instead 1.

So we do 1 message * 2 instances instead of 2 messages * 1 instance for more resiliency.