### PR TITLE
We only want current convictions so we can filter them when retrieving

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,11 +98,11 @@ tasks {
       rule {
         limit {
           counter = "BRANCH"
-          minimum = BigDecimal(0.82)
+          minimum = BigDecimal(0.83)
         }
         limit {
           counter = "COMPLEXITY"
-          minimum = BigDecimal(0.82)
+          minimum = BigDecimal(0.84)
         }
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/MandateForChange.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/MandateForChange.kt
@@ -13,10 +13,10 @@ class MandateForChange(
 ) {
   fun hasNoMandate(crn: String, convictions: Collection<Conviction>): Boolean =
     convictions
-      .filter { it.sentence?.terminationDate == null }
+      .filter { it.sentence.terminationDate == null }
       .let { activeConvictions ->
         activeConvictions.none {
-          it.sentence != null && (isCustodial(it.sentence) || hasNonRestrictiveRequirements(crn, it.convictionId))
+          (isCustodial(it.sentence) || hasNonRestrictiveRequirements(crn, it.convictionId))
         }
       }.also { log.debug("Has no mandate for change: $it") }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/ProtectLevelCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/ProtectLevelCalculator.kt
@@ -153,8 +153,8 @@ class ProtectLevelCalculator(
     communityApiClient.getBreachRecallNsis(crn, convictionId)
       .any { NsiOutcome.from(it.status?.code) != null }
 
-  private fun qualifyingConvictions(sentence: Sentence?): Boolean =
-    sentence?.terminationDate == null ||
+  private fun qualifyingConvictions(sentence: Sentence): Boolean =
+    sentence.terminationDate == null ||
       sentence.terminationDate.isAfter(LocalDate.now(clock).minusYears(1).minusDays(1))
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/TierCalculationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/TierCalculationService.kt
@@ -53,7 +53,7 @@ class TierCalculationService(
     val offenderAssessment = assessmentApiService.getRecentAssessment(crn)
     val deliusAssessments = communityApiClient.getDeliusAssessments(crn)
     val deliusRegistrations = communityApiClient.getRegistrations(crn)
-    val deliusConvictions = communityApiClient.getConvictions(crn)
+    val deliusConvictions = communityApiClient.getConvictionsWithSentences(crn)
 
     val protectLevel = protectLevelCalculator.calculateProtectLevel(
       crn,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/TierCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/TierCalculationServiceTest.kt
@@ -149,7 +149,7 @@ internal class TierCalculationServiceTest {
       every { assessmentApiService.getRecentAssessment(crn) } returns null // anything
       every { communityApiClient.getDeliusAssessments(crn) } returns null // anything
       every { communityApiClient.getRegistrations(crn) } returns listOf() // anything
-      every { communityApiClient.getConvictions(crn) } returns listOf() // anything
+      every { communityApiClient.getConvictionsWithSentences(crn) } returns listOf() // anything
 
       every { protectLevelCalculator.calculateProtectLevel(crn, any(), any(), any(), any()) } returns protectLevelResult
       every { changeLevelCalculator.calculateChangeLevel(crn, any(), any(), any(), any()) } returns changeLevelResult
@@ -168,7 +168,7 @@ internal class TierCalculationServiceTest {
       verify { assessmentApiService.getRecentAssessment(crn) }
       verify { communityApiClient.getDeliusAssessments(crn) }
       verify { communityApiClient.getRegistrations(crn) }
-      verify { communityApiClient.getConvictions(crn) }
+      verify { communityApiClient.getConvictionsWithSentences(crn) }
       verify { protectLevelCalculator.calculateProtectLevel(crn, any(), any(), any(), any()) }
       verify { changeLevelCalculator.calculateChangeLevel(crn, any(), any(), any(), any()) }
       verify { tierCalculationRepository.findFirstByCrnOrderByCreatedDesc(crn) }
@@ -180,7 +180,7 @@ internal class TierCalculationServiceTest {
       every { assessmentApiService.getRecentAssessment(crn) } returns null // anything
       every { communityApiClient.getDeliusAssessments(crn) } returns null // anything
       every { communityApiClient.getRegistrations(crn) } returns listOf() // anything
-      every { communityApiClient.getConvictions(crn) } returns listOf() // anything
+      every { communityApiClient.getConvictionsWithSentences(crn) } returns listOf() // anything
 
       every { protectLevelCalculator.calculateProtectLevel(crn, any(), any(), any(), any()) } returns protectLevelResult
       every { changeLevelCalculator.calculateChangeLevel(crn, any(), any(), any(), any()) } returns changeLevelResult
@@ -199,7 +199,7 @@ internal class TierCalculationServiceTest {
       verify { assessmentApiService.getRecentAssessment(crn) }
       verify { communityApiClient.getDeliusAssessments(crn) }
       verify { communityApiClient.getRegistrations(crn) }
-      verify { communityApiClient.getConvictions(crn) }
+      verify { communityApiClient.getConvictionsWithSentences(crn) }
       verify { protectLevelCalculator.calculateProtectLevel(crn, any(), any(), any(), any()) }
       verify { changeLevelCalculator.calculateChangeLevel(crn, any(), any(), any(), any()) }
       verify { tierCalculationRepository.findFirstByCrnOrderByCreatedDesc(crn) }


### PR DESCRIPTION
This reduces complexity and duplication (two null checks for sentence down to one). 
It does introduce another object though (ConvictionDto and Conviction).
We could get rid of quite a bit of complexity if we did more of this kind of filtering