### PR TITLE
Faster tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,6 +133,7 @@ tasks {
     args("--include-classname", ".*")
     args("--select-class", "uk.gov.justice.digital.hmpps.hmppstier.integration.bdd.CucumberRunnerTest")
     args("--exclude-tag", "disabled")
+
     // if you want to run one feature/scenario, tag it @single and uncomment
     // args("--include-tag", "single")
     args("--reports-dir", reportsDir)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/bdd/BddSteps.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/bdd/BddSteps.kt
@@ -53,6 +53,7 @@ class BddSteps : En {
 
   private lateinit var setupData: SetupData
 
+  private lateinit var crn: String
   private var oauthMock: ClientAndServer = startClientAndServer(9090)
   private var communityApi: ClientAndServer = startClientAndServer(8091)
   private var assessmentApi: ClientAndServer = startClientAndServer(8092)
@@ -66,12 +67,14 @@ class BddSteps : En {
 
   init {
 
-    Before { _: Scenario ->
+    Before { scenario: Scenario ->
       offenderEventsClient.purgeQueue(PurgeQueueRequest(eventQueueUrl))
       calculationCompleteClient.purgeQueue(PurgeQueueRequest(calculationCompleteUrl))
 
       setupOauth()
-      setupData = SetupData(communityApi, assessmentApi)
+      val re = Regex("[^A-Za-z0-9]")
+      crn = re.replace(scenario.name, "").replace(" ","")
+      setupData = SetupData(communityApi, assessmentApi, crn)
       tierCalculationRepository.deleteAll()
     }
 
@@ -195,7 +198,7 @@ class BddSteps : En {
 
     When("a tier is calculated") {
       setupData.prepareResponses()
-      putMessageOnQueue(offenderEventsClient, eventQueueUrl, "X12345")
+      putMessageOnQueue(offenderEventsClient, eventQueueUrl, crn)
     }
 
     Then("{string} points are scored") { points: String ->
@@ -220,6 +223,6 @@ class BddSteps : En {
     val sqsMessage: SQSMessage = gson.fromJson(message.messages[0].body, SQSMessage::class.java)
     val changeEvent: TierChangeEvent = gson.fromJson(sqsMessage.Message, TierChangeEvent::class.java)
 
-    return tierCalculationRepository.findByCrnAndUuid("X12345", changeEvent.calculationId)!!
+    return tierCalculationRepository.findByCrnAndUuid(crn, changeEvent.calculationId)!!
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/bdd/CucumberConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/bdd/CucumberConfig.kt
@@ -7,5 +7,6 @@ import org.springframework.test.context.ActiveProfiles
 
 @CucumberContextConfiguration
 @SpringBootTest(webEnvironment = RANDOM_PORT)
-@ActiveProfiles("test")
+@ActiveProfiles(profiles = arrayOf("test", "cucumber"))
+// @ActiveProfiles("test")
 class CucumberConfig

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/bdd/SetupData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/bdd/SetupData.kt
@@ -29,7 +29,7 @@ import uk.gov.justice.digital.hmpps.hmppstier.integration.setup.registrationsRes
 import java.math.BigDecimal
 import java.time.LocalDate
 
-class SetupData(private val communityApi: ClientAndServer, private val assessmentApi: ClientAndServer) {
+class SetupData(private val communityApi: ClientAndServer, private val assessmentApi: ClientAndServer, val crn: String) {
   private var sentenceLengthIndeterminate: Boolean = false
   private var sentenceLength: Long = 1
   private var mainOffence: String = "016"
@@ -109,7 +109,7 @@ class SetupData(private val communityApi: ClientAndServer, private val assessmen
   }
 
   fun prepareResponses() {
-    communityApiResponse(communityApiAssessmentsResponse(rsr), "/secure/offenders/crn/X12345/assessments")
+    communityApiResponse(communityApiAssessmentsResponse(rsr), "/secure/offenders/crn/$crn/assessments")
 
     when {
       rosh != "NO_ROSH" &&
@@ -137,12 +137,12 @@ class SetupData(private val communityApi: ClientAndServer, private val assessmen
     if (hasValidAssessment) {
       assessmentApiResponse(
         assessmentsApiAssessmentsResponse(LocalDate.now().year),
-        "/offenders/crn/X12345/assessments/summary"
+        "/offenders/crn/$crn/assessments/summary"
       )
       if (gender == "Female") {
         assessmentApiResponse(
           assessmentsApiFemaleAnswersResponse(assessmentAnswers),
-          "/assessments/oasysSetId/1234/answers"
+          "/assessments/oasysSetId/1234/answers" // possibly also a problem
         )
       }
       assessmentApiResponse(
@@ -166,8 +166,8 @@ class SetupData(private val communityApi: ClientAndServer, private val assessmen
     }
 
     when (gender) {
-      "Male" -> communityApiResponse(maleOffenderResponse(), "/secure/offenders/crn/X12345")
-      else -> communityApiResponse(femaleOffenderResponse(), "/secure/offenders/crn/X12345")
+      "Male" -> communityApiResponse(maleOffenderResponse(), "/secure/offenders/crn/$crn")
+      else -> communityApiResponse(femaleOffenderResponse(), "/secure/offenders/crn/$crn")
     }
 
     if (gender == "Female") {
@@ -184,7 +184,7 @@ class SetupData(private val communityApi: ClientAndServer, private val assessmen
   private fun breachAndRecall(response: HttpResponse) {
     communityApiResponseWithQs(
       response,
-      "/secure/offenders/crn/X12345/convictions/\\d+/nsis",
+      "/secure/offenders/crn/$crn/convictions/\\d+/nsis",
       Parameter("nsiCodes", "BRE,BRES,REC,RECS")
     )
   }
@@ -192,7 +192,7 @@ class SetupData(private val communityApi: ClientAndServer, private val assessmen
   private fun convictions(response: HttpResponse) {
     communityApiResponseWithQs(
       response,
-      "/secure/offenders/crn/X12345/convictions",
+      "/secure/offenders/crn/$crn/convictions",
       Parameter("activeOnly", "true")
     )
   }
@@ -204,7 +204,7 @@ class SetupData(private val communityApi: ClientAndServer, private val assessmen
   private fun registrations(response: HttpResponse) {
     communityApiResponseWithQs(
       response,
-      "/secure/offenders/crn/X12345/registrations", Parameter("activeOnly", "true")
+      "/secure/offenders/crn/$crn/registrations", Parameter("activeOnly", "true")
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/setup/ApiConfiguration.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/integration/setup/ApiConfiguration.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.hmppstier.integration.setup
+
+import org.mockserver.integration.ClientAndServer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@Profile("cucumber")
+class ApiConfiguration {
+
+  @Bean
+  fun oauthMock(): ClientAndServer = ClientAndServer.startClientAndServer(9090)
+
+  @Bean
+  fun communityApi(): ClientAndServer = ClientAndServer.startClientAndServer(8091)
+
+  @Bean
+  fun assessmentApi(): ClientAndServer = ClientAndServer.startClientAndServer(8092)
+}


### PR DESCRIPTION
Only starts up stubbed servers once
Could convert the existing integration tests to do the same (or just rewrite them as cucumber tests)