### PR TITLE
FIXBUILD: upgrade gradle plugin to fix dependency check

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 val cucumberVersion = "6.10.3"
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.1.6"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "3.2.0"
   kotlin("plugin.spring") version "1.4.30"
   kotlin("plugin.jpa") version "1.4.30"
   id("org.jlleitschuh.gradle.ktlint") version "9.4.1"


### PR DESCRIPTION
Also can upgrade Kotlin to 1.5 if we wanted to
https://github.com/ministryofjustice/dps-gradle-spring-boot/blob/main/release-notes/3.2.0.md