### PR TITLE
REFACTOR: extract additional factors for women

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/AdditionalFactorsForWomen.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/AdditionalFactorsForWomen.kt
@@ -1,0 +1,117 @@
+package uk.gov.justice.digital.hmpps.hmppstier.service
+
+import isCustodial
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppstier.client.CommunityApiClient
+import uk.gov.justice.digital.hmpps.hmppstier.client.Conviction
+import uk.gov.justice.digital.hmpps.hmppstier.client.OffenderAssessment
+import uk.gov.justice.digital.hmpps.hmppstier.client.Sentence
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.AdditionalFactorForWomen
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.NsiOutcome
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.OffenceCode
+import java.time.Clock
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+@Service
+class AdditionalFactorsForWomen(
+  private val clock: Clock,
+  private val communityApiClient: CommunityApiClient,
+  private val assessmentApiService: AssessmentApiService,
+  @Value("\${calculation.version}") private val calculationVersion: Int
+) {
+  fun getAdditionalFactorsForWomen(
+    crn: String,
+    convictions: Collection<Conviction>,
+    offenderAssessment: OffenderAssessment?
+  ): Int =
+    when {
+      isFemale(crn) -> {
+        val additionalFactorsPoints = getAdditionalFactorsAssessmentComplexityPoints(offenderAssessment)
+        val breachRecallPoints = getBreachRecallComplexityPoints(crn, convictions)
+
+        val violenceArsonPoints = if (calculationVersion > 1) getArsonOrViolencePoints(convictions) else 0
+
+        val tenMonthsPlusOrIndeterminatePoints =
+          if (calculationVersion > 1) getSentenceLengthPoints(convictions) else 0
+
+        additionalFactorsPoints + breachRecallPoints + violenceArsonPoints + tenMonthsPlusOrIndeterminatePoints
+      }
+      else -> 0
+    }
+
+  private fun isFemale(crn: String) = communityApiClient.getOffender(crn)?.gender.equals("female", true)
+
+  private fun getAdditionalFactorsAssessmentComplexityPoints(offenderAssessment: OffenderAssessment?): Int =
+    when (offenderAssessment) {
+      null -> 0
+      else -> {
+        assessmentApiService.getAssessmentAnswers(offenderAssessment.assessmentId)
+          .let { answers ->
+            val parenting = when {
+              isYes(answers[AdditionalFactorForWomen.PARENTING_RESPONSIBILITIES]) -> 1
+              else -> 0
+            }
+            // We dont take the cumulative score, just '1' if at least one of these two is present
+            val selfControl = when {
+              isAnswered(answers[AdditionalFactorForWomen.IMPULSIVITY]) || isAnswered(answers[AdditionalFactorForWomen.TEMPER_CONTROL]) -> 1
+              else -> 0
+            }
+            (parenting + selfControl).times(2)
+          }
+      }
+    }
+
+  private fun getArsonOrViolencePoints(convictions: Collection<Conviction>): Int =
+    if (convictions.flatMap { it.offences }
+      .map { it.offenceDetail }.any {
+        OFFENCE_CODES.contains(it.mainCategoryCode)
+      }
+    ) 2 else 0
+
+  private fun getSentenceLengthPoints(convictions: Collection<Conviction>): Int {
+
+    val custodialSentences = convictions.map { it.sentence }.filter { isCustodial(it) }
+    val custodialConvictions = convictions.filter { it.sentence in custodialSentences }
+
+    val longerThanTenMonths = custodialSentences.any {
+      it.startDate != null && it.expectedSentenceEndDate != null && sentenceTenMonthsOrOver(it)
+    }
+    val indeterminate = custodialConvictions.any { "303" == it.latestCourtAppearanceOutcome }
+    return if (longerThanTenMonths || indeterminate) 2 else 0
+  }
+
+  private fun sentenceTenMonthsOrOver(sentence: Sentence): Boolean {
+    val TEN_MONTHS_IN_DAYS: Long = 304
+    return ChronoUnit.DAYS.between(sentence.startDate, sentence.expectedSentenceEndDate!!) >= TEN_MONTHS_IN_DAYS
+  }
+
+  private fun getBreachRecallComplexityPoints(crn: String, convictions: Collection<Conviction>): Int =
+    convictions
+      .filter { qualifyingConvictions(it.sentence) }
+      .let {
+        when {
+          it.any { conviction -> convictionHasBreachOrRecallNsis(crn, conviction.convictionId) } -> 2
+          else -> 0
+        }
+      }
+
+  private fun isYes(value: String?): Boolean =
+    value.equals("YES", true) || value.equals("Y", true)
+
+  private fun isAnswered(value: String?): Boolean =
+    value?.toInt() ?: 0 > 0
+
+  private fun convictionHasBreachOrRecallNsis(crn: String, convictionId: Long): Boolean =
+    communityApiClient.getBreachRecallNsis(crn, convictionId)
+      .any { NsiOutcome.from(it.status?.code) != null }
+
+  private fun qualifyingConvictions(sentence: Sentence): Boolean =
+    sentence.terminationDate == null ||
+      sentence.terminationDate.isAfter(LocalDate.now(clock).minusYears(1).minusDays(1))
+
+  companion object {
+    val OFFENCE_CODES = OffenceCode.values().map { it.code }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/ProtectLevelCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/ProtectLevelCalculator.kt
@@ -1,37 +1,24 @@
 package uk.gov.justice.digital.hmpps.hmppstier.service
 
-import isCustodial
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppstier.client.CommunityApiClient
 import uk.gov.justice.digital.hmpps.hmppstier.client.Conviction
 import uk.gov.justice.digital.hmpps.hmppstier.client.DeliusAssessments
 import uk.gov.justice.digital.hmpps.hmppstier.client.OffenderAssessment
 import uk.gov.justice.digital.hmpps.hmppstier.client.Registration
-import uk.gov.justice.digital.hmpps.hmppstier.client.Sentence
 import uk.gov.justice.digital.hmpps.hmppstier.domain.TierLevel
-import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.AdditionalFactorForWomen
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.CalculationRule
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ComplexityFactor
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.Mappa
-import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.NsiOutcome
-import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.OffenceCode
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ProtectLevel
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.Rosh
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.RsrThresholds.TIER_B_RSR_LOWER
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.RsrThresholds.TIER_B_RSR_UPPER
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.RsrThresholds.TIER_C_RSR_LOWER
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.RsrThresholds.TIER_C_RSR_UPPER
-import java.time.Clock
-import java.time.LocalDate
-import java.time.temporal.ChronoUnit.DAYS
 
 @Service
 class ProtectLevelCalculator(
-  private val clock: Clock,
-  private val communityApiClient: CommunityApiClient,
-  private val assessmentApiService: AssessmentApiService,
-  @Value("\${calculation.version}") private val calculationVersion: Int
+  private val additionalFactorsForWomen: AdditionalFactorsForWomen
 ) {
 
   fun calculateProtectLevel(
@@ -47,7 +34,7 @@ class ProtectLevelCalculator(
       CalculationRule.ROSH to getRoshPoints(registrations),
       CalculationRule.MAPPA to getMappaPoints(registrations),
       CalculationRule.COMPLEXITY to getComplexityPoints(registrations),
-      CalculationRule.ADDITIONAL_FACTORS_FOR_WOMEN to getAdditionalFactorsForWomen(crn, convictions, offenderAssessment)
+      CalculationRule.ADDITIONAL_FACTORS_FOR_WOMEN to additionalFactorsForWomen.getAdditionalFactorsForWomen(crn, convictions, offenderAssessment)
     )
 
     val total = points.map { it.value }.sum()
@@ -102,98 +89,4 @@ class ProtectLevelCalculator(
       .distinct()
       .count()
       .times(2)
-
-  private fun getAdditionalFactorsForWomen(
-    crn: String,
-    convictions: Collection<Conviction>,
-    offenderAssessment: OffenderAssessment?
-  ): Int =
-    when {
-      isFemale(crn) -> {
-        val additionalFactorsPoints = getAdditionalFactorsAssessmentComplexityPoints(offenderAssessment)
-        val breachRecallPoints = getBreachRecallComplexityPoints(crn, convictions)
-
-        val violenceArsonPoints = if (calculationVersion > 1) getArsonOrViolencePoints(convictions) else 0
-
-        val tenMonthsPlusOrIndeterminatePoints =
-          if (calculationVersion > 1) getSentenceLengthPoints(convictions) else 0
-
-        additionalFactorsPoints + breachRecallPoints + violenceArsonPoints + tenMonthsPlusOrIndeterminatePoints
-      }
-      else -> 0
-    }
-
-  private fun isFemale(crn: String) = communityApiClient.getOffender(crn)?.gender.equals("female", true)
-
-  private fun getAdditionalFactorsAssessmentComplexityPoints(offenderAssessment: OffenderAssessment?): Int =
-    when (offenderAssessment) {
-      null -> 0
-      else -> {
-        assessmentApiService.getAssessmentAnswers(offenderAssessment.assessmentId)
-          .let { answers ->
-            val parenting = when {
-              isYes(answers[AdditionalFactorForWomen.PARENTING_RESPONSIBILITIES]) -> 1
-              else -> 0
-            }
-            // We dont take the cumulative score, just '1' if at least one of these two is present
-            val selfControl = when {
-              isAnswered(answers[AdditionalFactorForWomen.IMPULSIVITY]) || isAnswered(answers[AdditionalFactorForWomen.TEMPER_CONTROL]) -> 1
-              else -> 0
-            }
-            (parenting + selfControl).times(2)
-          }
-      }
-    }
-
-  private fun getArsonOrViolencePoints(convictions: Collection<Conviction>): Int =
-    if (convictions.flatMap { it.offences }
-      .map { it.offenceDetail }.any {
-        OFFENCE_CODES.contains(it.mainCategoryCode)
-      }
-    ) 2 else 0
-
-  private fun getSentenceLengthPoints(convictions: Collection<Conviction>): Int {
-
-    val custodialSentences = convictions.map { it.sentence }.filter { isCustodial(it) }
-    val custodialConvictions = convictions.filter { it.sentence in custodialSentences }
-
-    val longerThanTenMonths = custodialSentences.any {
-      it.startDate != null && it.expectedSentenceEndDate != null && sentenceTenMonthsOrOver(it)
-    }
-    val indeterminate = custodialConvictions.any { "303" == it.latestCourtAppearanceOutcome }
-    return if (longerThanTenMonths || indeterminate) 2 else 0
-  }
-
-  private fun sentenceTenMonthsOrOver(sentence: Sentence): Boolean {
-    val TEN_MONTHS_IN_DAYS: Long = 304
-    return DAYS.between(sentence.startDate, sentence.expectedSentenceEndDate!!) >= TEN_MONTHS_IN_DAYS
-  }
-
-  private fun getBreachRecallComplexityPoints(crn: String, convictions: Collection<Conviction>): Int =
-    convictions
-      .filter { qualifyingConvictions(it.sentence) }
-      .let {
-        when {
-          it.any { conviction -> convictionHasBreachOrRecallNsis(crn, conviction.convictionId) } -> 2
-          else -> 0
-        }
-      }
-
-  private fun isYes(value: String?): Boolean =
-    value.equals("YES", true) || value.equals("Y", true)
-
-  private fun isAnswered(value: String?): Boolean =
-    value?.toInt() ?: 0 > 0
-
-  private fun convictionHasBreachOrRecallNsis(crn: String, convictionId: Long): Boolean =
-    communityApiClient.getBreachRecallNsis(crn, convictionId)
-      .any { NsiOutcome.from(it.status?.code) != null }
-
-  private fun qualifyingConvictions(sentence: Sentence): Boolean =
-    sentence.terminationDate == null ||
-      sentence.terminationDate.isAfter(LocalDate.now(clock).minusYears(1).minusDays(1))
-
-  companion object {
-    val OFFENCE_CODES = OffenceCode.values().map { it.code }
-  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/ProtectLevelCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/ProtectLevelCalculator.kt
@@ -6,11 +6,25 @@ import uk.gov.justice.digital.hmpps.hmppstier.client.DeliusAssessments
 import uk.gov.justice.digital.hmpps.hmppstier.client.OffenderAssessment
 import uk.gov.justice.digital.hmpps.hmppstier.client.Registration
 import uk.gov.justice.digital.hmpps.hmppstier.domain.TierLevel
-import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.CalculationRule
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.CalculationRule.ADDITIONAL_FACTORS_FOR_WOMEN
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.CalculationRule.COMPLEXITY
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.CalculationRule.MAPPA
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.CalculationRule.ROSH
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.CalculationRule.RSR
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ComplexityFactor
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.Mappa
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.Mappa.M1
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.Mappa.M2
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.Mappa.M3
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ProtectLevel
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ProtectLevel.A
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ProtectLevel.B
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ProtectLevel.C
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.ProtectLevel.D
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.Rosh
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.Rosh.HIGH
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.Rosh.MEDIUM
+import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.Rosh.VERY_HIGH
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.RsrThresholds.TIER_B_RSR_LOWER
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.RsrThresholds.TIER_B_RSR_UPPER
 import uk.gov.justice.digital.hmpps.hmppstier.domain.enums.RsrThresholds.TIER_C_RSR_LOWER
@@ -30,21 +44,21 @@ class ProtectLevelCalculator(
   ): TierLevel<ProtectLevel> {
 
     val points = mapOf(
-      CalculationRule.RSR to getRsrPoints(deliusAssessments),
-      CalculationRule.ROSH to getRoshPoints(registrations),
-      CalculationRule.MAPPA to getMappaPoints(registrations),
-      CalculationRule.COMPLEXITY to getComplexityPoints(registrations),
-      CalculationRule.ADDITIONAL_FACTORS_FOR_WOMEN to additionalFactorsForWomen.calculate(crn, convictions, offenderAssessment)
+      RSR to getRsrPoints(deliusAssessments),
+      ROSH to getRoshPoints(registrations),
+      MAPPA to getMappaPoints(registrations),
+      COMPLEXITY to getComplexityPoints(registrations),
+      ADDITIONAL_FACTORS_FOR_WOMEN to additionalFactorsForWomen.calculate(crn, convictions, offenderAssessment)
     )
 
     val total = points.map { it.value }.sum()
-      .minus(minOf(points.getOrDefault(CalculationRule.RSR, 0), points.getOrDefault(CalculationRule.ROSH, 0)))
+      .minus(minOf(points.getOrDefault(RSR, 0), points.getOrDefault(ROSH, 0)))
 
     return when {
-      total >= 30 -> TierLevel(ProtectLevel.A, total, points)
-      total in 20..29 -> TierLevel(ProtectLevel.B, total, points)
-      total in 10..19 -> TierLevel(ProtectLevel.C, total, points)
-      else -> TierLevel(ProtectLevel.D, total, points)
+      total >= 30 -> TierLevel(A, total, points)
+      total in 20..29 -> TierLevel(B, total, points)
+      total in 10..19 -> TierLevel(C, total, points)
+      else -> TierLevel(D, total, points)
     }
   }
 
@@ -64,9 +78,9 @@ class ProtectLevelCalculator(
       .firstOrNull()
       .let { rosh ->
         when (rosh) {
-          Rosh.VERY_HIGH -> 30
-          Rosh.HIGH -> 20
-          Rosh.MEDIUM -> 10
+          VERY_HIGH -> 30
+          HIGH -> 20
+          MEDIUM -> 10
           else -> 0
         }
       }
@@ -77,8 +91,8 @@ class ProtectLevelCalculator(
       .firstOrNull()
       .let { mappa ->
         when (mappa) {
-          Mappa.M3, Mappa.M2 -> 30
-          Mappa.M1 -> 5
+          M3, M2 -> 30
+          M1 -> 5
           else -> 0
         }
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/ProtectLevelCalculator.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/ProtectLevelCalculator.kt
@@ -34,7 +34,7 @@ class ProtectLevelCalculator(
       CalculationRule.ROSH to getRoshPoints(registrations),
       CalculationRule.MAPPA to getMappaPoints(registrations),
       CalculationRule.COMPLEXITY to getComplexityPoints(registrations),
-      CalculationRule.ADDITIONAL_FACTORS_FOR_WOMEN to additionalFactorsForWomen.getAdditionalFactorsForWomen(crn, convictions, offenderAssessment)
+      CalculationRule.ADDITIONAL_FACTORS_FOR_WOMEN to additionalFactorsForWomen.calculate(crn, convictions, offenderAssessment)
     )
 
     val total = points.map { it.value }.sum()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/ProtectLevelCalculatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/ProtectLevelCalculatorTest.kt
@@ -46,10 +46,12 @@ internal class ProtectLevelCalculatorTest {
   private val assessmentApiService: AssessmentApiService = mockk(relaxUnitFun = true)
 
   private val service = ProtectLevelCalculator(
-    clock,
-    communityApiClient,
-    assessmentApiService,
-    1
+    AdditionalFactorsForWomen(
+      clock,
+      communityApiClient,
+      assessmentApiService,
+      1
+    )
   )
 
   private val crn = "Any Crn"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/ProtectLevelTwoCalculatorTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/ProtectLevelTwoCalculatorTest.kt
@@ -37,10 +37,12 @@ internal class ProtectLevelTwoCalculatorTest {
   private val assessmentApiService: AssessmentApiService = mockk(relaxUnitFun = true)
 
   private val service = ProtectLevelCalculator(
-    clock,
-    communityApiClient,
-    assessmentApiService,
-    2
+    AdditionalFactorsForWomen(
+      clock,
+      communityApiClient,
+      assessmentApiService,
+      2
+    )
   )
 
   private val crn = "Any Crn"


### PR DESCRIPTION
This was a bit of an eye opener! Protect level calculator is actually quite simple apart from this!

Most important things I learned

- All dependencies moved from ProtectLevelCalculator to AdditionalFactorsForWomen
- All arguments to AdditionalFactorsForWomen are passed through ProtectLevelCalculator and not used elsewhere in it

BEFORE: 
TooManyFunctions - 16/11 - [ProtectLevelCalculator] at /Users/markrees/workspace/hmpps-tier/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/ProtectLevelCalculator.kt:30:7
AFTER: 
TooManyFunctions - 11/11 - [AdditionalFactorsForWomen] at /Users/markrees/workspace/hmpps-tier/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/AdditionalFactorsForWomen.kt:18:7