### PR TITLE
BUILD: dependency check job configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ workflows:
           requires:
             - request-prod-approval
 
-  scheduled:
+  security:
     triggers:
       - schedule:
           cron: "0 6 * * 1-5"
@@ -100,7 +100,6 @@ workflows:
               only:
                 - main
     jobs:
-      - owasp/gradle_owasp_dependency_check:
-          executor:
-            name: hmpps/java
-            tag: "16.0"
+      - hmpps/gradle_owasp_dependency_check:
+          context:
+            - hmpps-common-vars


### PR DESCRIPTION
Fixing this problem
https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-tier-to-delius-update/167/workflows/93d683e1-f180-4d46-b244-1216a988d4e2/jobs/409

Fix has been verified here
https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-tier-sqs-tool/133/workflows/03a9c446-f587-4e0a-b316-20cf9e688ba7/jobs/358

But I can't push to main on hmpps-tier as it's protected 👮‍♀️ 
So please review today so that it will work when it runs as scheduled tomorrow at 7am
