### PR TITLE
WFP-871 Added DXW VPN to dev environment

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,4 +11,4 @@ generic-service:
     ASSESSMENT_ENDPOINT_URL: https://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk
 
   allowlist:
-    dxw-vpn: "54.76.254.148"
+    dxw-vpn: "54.76.254.148/32"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,3 +10,5 @@ generic-service:
     COMMUNITY_ENDPOINT_URL: https://community-api.test.probation.service.justice.gov.uk/secure
     ASSESSMENT_ENDPOINT_URL: https://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk
 
+  allowlist:
+    dxw-vpn: "54.76.254.148"


### PR DESCRIPTION
DXW want access to the Swagger API docs that are published from the `hmpps-tier-dev` namespace.
Tested on the command line that their VPN IP address `54.76.254.148` is only added in dev:

```
➜  helm_deploy git:(main) ✗ helm template hmpps-tier --values=values-dev.yaml | grep whitelist
    nginx.ingress.kubernetes.io/whitelist-source-range: "35.178.209.113/32,3.8.51.207/32,35.177.252.54/32,54.76.254.148/32,35.177.252.195/32,81.134.202.29/32,217.33.148.210/32"
➜  helm_deploy git:(main) ✗ helm template hmpps-tier --values=values-preprod.yaml | grep whitelist
    nginx.ingress.kubernetes.io/whitelist-source-range: "35.178.209.113/32,3.8.51.207/32,35.177.252.54/32,35.177.252.195/32,81.134.202.29/32,217.33.148.210/32"
➜  helm_deploy git:(main) ✗ helm template hmpps-tier --values=values-prod.yaml | grep whitelist
    nginx.ingress.kubernetes.io/whitelist-source-range: "35.178.209.113/32,3.8.51.207/32,35.177.252.54/32,35.177.252.195/32,81.134.202.29/32,217.33.148.210/32"
```