### PR TITLE
PI-463 Only send success event after completed transaction

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/TierCalculationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstier/service/TierCalculationServiceTest.kt
@@ -37,14 +37,12 @@ internal class TierCalculationServiceTest {
   private val assessmentApiService: AssessmentApiService = mockk(relaxUnitFun = true)
   private val communityApiService: CommunityApiService = mockk(relaxUnitFun = true)
   private val telemetryService: TelemetryService = mockk(relaxUnitFun = true)
-  private val successUpdater: SuccessUpdater = mockk(relaxUnitFun = true)
 
   private val service = TierCalculationService(
     clock,
     tierCalculationRepository,
     assessmentApiService,
     communityApiService,
-    successUpdater,
     telemetryService
   )
 


### PR DESCRIPTION
This PR moves the call to `successUpdater` out of the `@Transactional` service method.  This ensures the TIER_CALCULATION_COMPLETE event is only emitted if the transaction has completed, and also prevents race conditions that occur due to the event being emitted too early (see Slack thread: https://mojdt.slack.com/archives/C035YK9FFK4/p1665733541723359).