### PR TITLE
PI-1613 Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.3.3
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.12.5
 
 parameters:
@@ -24,13 +24,15 @@ jobs:
       - hmpps/install_aws_cli
       - run:
           name: Wait for SQS to be ready
-          command: curl -4 --connect-timeout 30 --retry-connrefused --retry 2 --retry-delay 5 http://localhost:4566
+          command: curl -4 --connect-timeout 30 --retry-connrefused --retry 2
+            --retry-delay 5 http://localhost:4566
       - restore_cache:
           keys:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
       - run:
-          command: ./gradlew -Dorg.gradle.jvmargs="--illegal-access=permit" -Dkotlin.daemon.jvm.options="--illegal-access=permit" check
+          command: ./gradlew -Dorg.gradle.jvmargs="--illegal-access=permit"
+            -Dkotlin.daemon.jvm.options="--illegal-access=permit" check
       - when:
           condition:
             equal: [ main, << pipeline.git.branch >> ]

--- a/helm_deploy/hmpps-tier/Chart.yaml
+++ b/helm_deploy/hmpps-tier/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-tier
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.7.1
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/hmpps-tier/values.yaml
+++ b/helm_deploy/hmpps-tier/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-tier
 
@@ -6,14 +5,14 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-tier
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
     enabled: true
     v1_2_enabled: true
     v0_47_enabled: false
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-tier-cert
     contextColour: green
     path: /
@@ -66,26 +65,9 @@ generic-service:
       HMPPS_SQS_QUEUES_HMPPSDOMAINEVENTSQUEUE_DLQ_NAME: "sqs_queue_name"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    unilink-aovpn1: "194.75.210.216/29"
-    unilink-aovpn2: "83.98.63.176/29"
-    unilink-aovpn3: "78.33.10.50/31"
-    unilink-aovpn4: "78.33.10.52/30"
-    unilink-aovpn5: "78.33.10.56/30"
-    unilink-aovpn6: "78.33.10.60/32"
-    unilink-aovpn7: "78.33.32.99/32"
-    unilink-aovpn8: "78.33.32.100/30"
-    unilink-aovpn9: "78.33.32.104/30"
-    unilink-aovpn10: "78.33.32.108/32"
-    unilink-aovpn11: "217.138.45.109/32"
-    unilink-aovpn12: "217.138.45.110/32"
+    groups:
+      - internal
+      - unilink_staff
 
   serviceAccountName: hmpps-tier
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-tier/values.yaml
 
 generic-service:
@@ -11,10 +10,11 @@ generic-service:
     HMPPS_TIER_ENDPOINT_URL: https://hmpps-tier-dev.hmpps.service.justice.gov.uk
     TIER_TO_DELIUS_ENDPOINT_URL: https://tier-to-delius-dev.hmpps.service.justice.gov.uk
   allowlist:
-    dxw-vpn: "54.76.254.148/32"
-    delius-test-1: "35.176.126.163/32"
-    delius-test-2: "35.178.162.73/32"
-    delius-test-3: "52.56.195.113/32"
+    dxw-vpn: 54.76.254.148/32
+    delius-test-1: 35.176.126.163/32
+    delius-test-2: 35.178.162.73/32
+    delius-test-3: 52.56.195.113/32
+    groups: []
   scheduledDowntime:
     enabled: true
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-tier/values.yaml
 
 generic-service:
@@ -12,9 +11,10 @@ generic-service:
     TIER_TO_DELIUS_ENDPOINT_URL: https://tier-to-delius-preprod.hmpps.service.justice.gov.uk
     HMPPS_SQS_USE_WEB_TOKEN: "true"
   allowlist:
-    delius-pre-prod-1: "52.56.240.62/32"
-    delius-pre-prod-2: "18.130.110.168/32"
-    delius-pre-prod-3: "35.178.44.184/32"
+    delius-pre-prod-1: 52.56.240.62/32
+    delius-pre-prod-2: 18.130.110.168/32
+    delius-pre-prod-3: 35.178.44.184/32
+    groups: []
   scheduledDowntime:
     enabled: true
   namespace_secrets:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-tier/values.yaml
 
 generic-service:
@@ -12,9 +11,10 @@ generic-service:
     TIER_TO_DELIUS_ENDPOINT_URL: https://tier-to-delius.hmpps.service.justice.gov.uk
 
   allowlist:
-    delius-prod-1: "52.56.115.146/32"
-    delius-prod-2: "35.178.104.253/32"
-    delius-prod-3: "35.177.47.45/32"
+    delius-prod-1: 52.56.115.146/32
+    delius-prod-2: 35.178.104.253/32
+    delius-prod-3: 35.177.47.45/32
+    groups: []
 
 generic-prometheus-alerts:
   sqsOldestAlertQueueNames:


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

4 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-tier/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal`
- The size of the allowlist defined in this file will change: `20 => 12 (8 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick (35.177.252.195/32)
  

## Allowlist: helm_deploy/values-dev.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `4 => 4 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  

## Allowlist: helm_deploy/values-preprod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `3 => 3 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  

## Allowlist: helm_deploy/values-prod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `3 => 3 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  
