### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/hmpps-tier/values.yaml
+++ b/helm_deploy/hmpps-tier/values.yaml
@@ -65,9 +65,8 @@ generic-service:
       HMPPS_SQS_QUEUES_HMPPSDOMAINEVENTSQUEUE_DLQ_NAME: "sqs_queue_name"
 
   allowlist:
-    groups:
-      - internal
-      - unilink_staff
+    undefined: internal,unilink_staff/32
+    groups: []
 
   serviceAccountName: hmpps-tier
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,5 +1,3 @@
-# Per environment values which override defaults in hmpps-tier/values.yaml
-
 generic-service:
   ingress:
     host: hmpps-tier-dev.hmpps.service.justice.gov.uk
@@ -14,6 +12,7 @@ generic-service:
     delius-test-1: 35.176.126.163/32
     delius-test-2: 35.178.162.73/32
     delius-test-3: 52.56.195.113/32
+    groups: []
   scheduledDowntime:
     enabled: true
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,5 +1,3 @@
-# Per environment values which override defaults in hmpps-tier/values.yaml
-
 generic-service:
   ingress:
     host: hmpps-tier-preprod.hmpps.service.justice.gov.uk
@@ -14,6 +12,7 @@ generic-service:
     delius-pre-prod-1: 52.56.240.62/32
     delius-pre-prod-2: 18.130.110.168/32
     delius-pre-prod-3: 35.178.44.184/32
+    groups: []
   scheduledDowntime:
     enabled: true
   namespace_secrets:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,5 +1,3 @@
-# Per environment values which override defaults in hmpps-tier/values.yaml
-
 generic-service:
   ingress:
     host: hmpps-tier.hmpps.service.justice.gov.uk
@@ -14,6 +12,7 @@ generic-service:
     delius-prod-1: 52.56.115.146/32
     delius-prod-2: 35.178.104.253/32
     delius-prod-3: 35.177.47.45/32
+    groups: []
 
 generic-prometheus-alerts:
   sqsOldestAlertQueueNames:


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

4 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-tier/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `1 => 1 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  

## Allowlist: helm_deploy/values-dev.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `4 => 4 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  

## Allowlist: helm_deploy/values-preprod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `3 => 3 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  

## Allowlist: helm_deploy/values-prod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `3 => 3 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  
