### PR TITLE
PI-2600 Generate recalculation messages in job pod

### DIFF
--- a/helm_deploy/hmpps-tier/templates/recalcuate-all-cases.yaml
+++ b/helm_deploy/hmpps-tier/templates/recalcuate-all-cases.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: recalculate-tiers
 spec:
-  schedule: {{ .Values.recalculate.tier.schedule }}
+  schedule: {{ index .Values "full-recalculation" "schedule" }}
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 1
@@ -13,28 +13,40 @@ spec:
         spec:
           containers:
             - name: recalculate-tiers
-              image: ghcr.io/ministryofjustice/hmpps-devops-tools
-              args:
-                - /bin/sh
-                - -c
-                - 'curl -fsSL -X POST "https://$BASE_URL/calculations?dryRun=$DRY_RUN" --header "Authorization: Bearer $(curl -fsSL --request POST "$AUTH_BASE_URL/oauth/token?grant_type=client_credentials" --user "$CLIENT_ID:$CLIENT_SECRET"  | jq -r .access_token)" --header "Content-Type: application/json"'
+              image: "quay.io/hmpps/hmpps-tier:{{ index .Values "generic-service" "image" "tag" }}"
+              securityContext:
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                seccompProfile:
+                  type: RuntimeDefault
+              resources:
+                requests:
+                  memory: "1Gi"
+                  cpu: "4"
+                limits:
+                  memory: "2Gi"
+                  cpu: "4"
               env:
-                - name: AUTH_BASE_URL
-                  value: {{ index .Values "generic-service" "env" "OAUTH_ENDPOINT_URL" }}
-                - name: BASE_URL
-                  value: {{ index .Values "generic-service" "ingress" "host" }}
-                - name: DRY_RUN
-                  value: "{{ index .Values "generic-service" "env" "FULL_RECALC_DRY_RUN" }}"
-                - name: CLIENT_ID
+                {{- range $secret, $envs := index .Values "generic-service" "namespace_secrets" }}
+                  {{- range $key, $val := $envs }}
+                - name: {{ $key }}
                   valueFrom:
                     secretKeyRef:
-                      name: hmpps-tier
-                      key: OAUTH_CLIENT_ID
-                      optional: false
-                - name: CLIENT_SECRET
-                  valueFrom:
-                    secretKeyRef:
-                      name: hmpps-tier
-                      key: OAUTH_CLIENT_SECRET
-                      optional: false
+                      key: {{ trimSuffix "?" $val }}
+                      name: {{ $secret }}{{ if hasSuffix "?" $val }}
+                      optional: true{{ end }}  {{- end }}
+                {{- end }}
+                {{- range $key, $val := index .Values "generic-service" "env" }}
+                - name: {{ $key }}
+                  value: "{{ $val }}"
+                {{- end }}
+                - name: MESSAGING_CONSUMER_ENABLED
+                  value: "false"
+                - name: FULL-RECALCULATION_ENABLED
+                  value: "true"
+                - name: FULL-RECALCULATION_DRY-RUN
+                  value: "{{ index .Values "full-recalculation" "dry-run" }}"
           restartPolicy: Never

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -9,7 +9,6 @@ generic-service:
     ARNS_ENDPOINT_URL: https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk
     HMPPS_TIER_ENDPOINT_URL: https://hmpps-tier-dev.hmpps.service.justice.gov.uk
     TIER_TO_DELIUS_ENDPOINT_URL: https://tier-to-delius-dev.hmpps.service.justice.gov.uk
-    FULL_RECALC_DRY_RUN: "false"
     TIER_UNSUPERVISED_SUFFIX: "true"
     SENTRY_ENVIRONMENT: dev
 
@@ -27,6 +26,6 @@ generic-prometheus-alerts:
     - "manage-a-workforce-development-hmpps_tier_domain_events_dlq"
   sqsAlertsTotalMessagesThreshold: 1
 
-recalculate:
-  tier:
-    schedule: 30 6 * * 1
+full-recalculation:
+  schedule: 30 6 * * 1
+  dry-run: false

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -9,7 +9,6 @@ generic-service:
     ARNS_ENDPOINT_URL: https://assess-risks-and-needs-preprod.hmpps.service.justice.gov.uk
     HMPPS_TIER_ENDPOINT_URL: https://hmpps-tier-preprod.hmpps.service.justice.gov.uk
     TIER_TO_DELIUS_ENDPOINT_URL: https://tier-to-delius-preprod.hmpps.service.justice.gov.uk
-    FULL_RECALC_DRY_RUN: "false"
     TIER_UNSUPERVISED_SUFFIX: "true"
     SENTRY_ENVIRONMENT: preprod
 
@@ -35,6 +34,6 @@ generic-prometheus-alerts:
     - "manage-a-workforce-preproduction-hmpps_tier_domain_events_dlq"
   sqsAlertsTotalMessagesThreshold: 1
 
-recalculate:
-  tier:
-    schedule: 30 6 * * 1
+full-recalculation:
+  schedule: 30 6 * * 1
+  dry-run: false

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -9,7 +9,6 @@ generic-service:
     ARNS_ENDPOINT_URL: http://hmpps-assess-risks-and-needs.hmpps-assess-risks-and-needs-prod.svc.cluster.local
     HMPPS_TIER_ENDPOINT_URL: https://hmpps-tier.hmpps.service.justice.gov.uk
     TIER_TO_DELIUS_ENDPOINT_URL: http://tier-to-delius.hmpps-probation-integration-services-prod.svc.cluster.local
-    FULL_RECALC_DRY_RUN: "false"
     TIER_UNSUPERVISED_SUFFIX: "true"
     SENTRY_ENVIRONMENT: prod
 
@@ -27,6 +26,6 @@ generic-prometheus-alerts:
   sqsAlertsTotalMessagesThreshold: 1
   ingress5xxErrorWindowMinutes: 4
 
-recalculate:
-  tier:
-    schedule: 0 18 * * 5
+full-recalculation:
+  schedule: 0 18 * * 5
+  dry-run: false

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/controller/DomainEventsListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/controller/DomainEventsListener.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.awspring.cloud.sqs.annotation.SqsListener
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.dao.CannotAcquireLockException
 import org.springframework.jdbc.CannotGetJdbcConnectionException
 import org.springframework.orm.ObjectOptimisticLockingFailureException
@@ -18,6 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppstier.service.RecalculationSource
 import uk.gov.justice.digital.hmpps.hmppstier.service.TierCalculationService
 
 @Service
+@ConditionalOnProperty("messaging.consumer.enabled", matchIfMissing = true)
 class DomainEventsListener(
     private val calculator: TierCalculationService,
     private val objectMapper: ObjectMapper,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/cronjob/FullRecalculationRunner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/cronjob/FullRecalculationRunner.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.hmppstier.cronjob
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.SpringApplication.exit
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.event.ApplicationStartedEvent
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationListener
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppstier.service.TriggerCalculationService
+import kotlin.system.exitProcess
+
+@Component
+@ConditionalOnProperty("full-recalculation.enabled")
+class FullRecalculationRunner(
+    @Value("\${full-recalculation.dry-run:false}")
+    private val dryRun: Boolean,
+    private val service: TriggerCalculationService,
+    private val applicationContext: ApplicationContext
+) : ApplicationListener<ApplicationStartedEvent> {
+    override fun onApplicationEvent(applicationStartedEvent: ApplicationStartedEvent) {
+        service.recalculateAll(dryRun)
+        exitProcess(exit(applicationContext, { 0 }))
+    }
+}


### PR DESCRIPTION
Currently, the cron job calls an API to trigger the message generation on one of the app pods, which causes contention for CPU and memory as the app pods are also listening for messages and responding to API calls.

This change updates the cronjob to run the hmpps-tier image and generate the SQS messages directly from the job's pod, leaving the app pods to focus on processing the generated messages.