### PR TITLE
PI-2600 Use uri variables to reduce metric tags

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/client/ArnsApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/client/ArnsApiClient.kt
@@ -19,7 +19,7 @@ class ArnsApiClient(
 ) {
     fun getTierAssessmentInformation(crn: String): AssessmentForTier? = restClient
         .get()
-        .uri("/tier-assessment/sections/$crn")
+        .uri("/tier-assessment/sections/{crn}", crn)
         .exchange<AssessmentForTier?> { _, res ->
             when (res.statusCode) {
                 HttpStatus.OK -> objectMapper.readValue(res.body)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/client/TierToDeliusApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/client/TierToDeliusApiClient.kt
@@ -22,7 +22,7 @@ class TierToDeliusApiClient(
     fun getDeliusTier(crn: String): TierToDeliusResponse {
         return restClient
             .get()
-            .uri("/tier-details/$crn")
+            .uri("/tier-details/{crn}", crn)
             .exchange { req, res ->
                 when (res.statusCode) {
                     HttpStatus.OK -> objectMapper.readValue<TierToDeliusResponse>(res.body)


### PR DESCRIPTION
Resolves errors in logs:
```
Reached the maximum number of URI tags for 'http.client.requests'. Are you using 'uriVariables'?
```