### PR TITLE
Replace create_app_version action with hmpps-github-shared-actions v1

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - id: app_version
         name: Application version creators
-        uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/create_app_version@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # v2.13.1
+        uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/build-test-and-deploy/create_app_version@f52dbae537425d92f2216c4a2d9e0e44e603abb1 #v1
   gradle_verify:
     name: Validate the kotlin
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/gradle_verify.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # v2.13.1


### PR DESCRIPTION
## What
Replaces old `create_app_version` action references in `pipeline.yml` with:
- `ministryofjustice/hmpps-github-shared-actions/.github/actions/build-test-and-deploy/create_app_version@f52dbae537425d92f2216c4a2d9e0e44e603abb1 #v1`

## Why
The shared actions have moved repository.

## Notes
- Only updates `.github/workflows/pipeline.yml`
- Converts any existing ref/hash/version for `create_app_version`