### PR TITLE
PI-3970 Fix event type check for CONVICTION_CHANGED

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/messaging/consumer/SQSMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstier/messaging/consumer/SQSMessage.kt
@@ -13,7 +13,7 @@ data class SQSMessage(
         private val attributes: MutableMap<String, MessageAttribute> = mutableMapOf(),
     ) : MutableMap<String, MessageAttribute> by attributes {
 
-        val eventType = attributes[EVENT_TYPE_KEY]?.value
+        val eventType get() = attributes[EVENT_TYPE_KEY]?.value
 
         companion object {
             private const val EVENT_TYPE_KEY = "eventType"


### PR DESCRIPTION
Previously it was reading the eventType value on construction, before the JSON was parsed, so it was always null